### PR TITLE
Conditional sleep time added to gitpod tab init commands

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -2,12 +2,12 @@ image: marcopeg/gitpod-workspace-postgres:2.5.0
 
 tasks:
   - name: Unit Tests
-    init: while ! curl -I $(gp url 8008) | grep "HTTP/2 200" ; do sleep 30; done
+    init: while ! find ./node_modules/.bin/jest ; do sleep 30; done
     command: yarn tdd:unit
     openIn: right
     openMode: tab-after
   - name: E2E Tests
-    init: while ! curl -I $(gp url 8008) | grep "HTTP/2 200" ; do sleep 30; done
+    init: while ! find ./node_modules/.bin/jest ; do sleep 30; done
     command: yarn tdd:e2e
     openIn: right
     openMode: tab-after
@@ -17,12 +17,12 @@ tasks:
     openIn: bottom
     openMode: tab-after
   - name: Styleguide
-    init: while ! curl -I $(gp url 8008) | grep "HTTP/2 200" ; do sleep 30; done
+    init: while ! find ./node_modules/.bin/styleguidist ; do sleep 30; done
     command: yarn start:gitpod:styleguide
     openIn: bottom
     openMode: split-right
   - name: App
-    init: while ! curl -I $(gp url 8008) | grep "HTTP/2 200" ; do sleep 30; done
+    init: while ! find ./node_modules/.bin/react-scripts ; do sleep 30; done
     command: yarn start:gitpod:app
     openIn: bottom
     openMode: tab-after


### PR DESCRIPTION
The current tabs don't start correctly as the commands are not available after 60 seconds (node modules not yet installed). I added a conditional sleep time to address that.

Let me know if you find a way to test this outside of the master branch as I couldn't